### PR TITLE
Fix the casting integer to double within RecipeItem building

### DIFF
--- a/app/src/main/java/Entities/Builders/RecipeItemBuilder.java
+++ b/app/src/main/java/Entities/Builders/RecipeItemBuilder.java
@@ -45,7 +45,7 @@ public class RecipeItemBuilder extends AbstractBuilder<RecipeItem> {
 
 		String rawID;
 		String rawIngredientID;
-		Double rawQuantity;
+		double quantity;
 		boolean optional;
 		String displayType;
 
@@ -54,7 +54,7 @@ public class RecipeItemBuilder extends AbstractBuilder<RecipeItem> {
 			// Attempt to retrieve required data.
 			rawID = row.get("id", String.class);
 			rawIngredientID = row.get("ingredient", String.class);
-			rawQuantity = row.get("quantity", Double.class);
+			quantity = row.get("quantity", Number.class).doubleValue();
 			optional = row.get("optional", Boolean.class);
 			displayType = row.get("displayType", String.class);
 
@@ -65,7 +65,6 @@ public class RecipeItemBuilder extends AbstractBuilder<RecipeItem> {
 		// Create the proper objects for construction.
 		UUID id = UUID.fromString(rawID);
 		UUID ingredientID = UUID.fromString(rawIngredientID);
-		float quantity = rawQuantity.floatValue();
 
 		Reference<Ingredient> ingredientReference = new Reference<>(ingredientID, this.ingredientStorage);
 		Ingredient ingredient = new ReferencedIngredient(ingredientReference);

--- a/app/src/main/java/Entities/Implementations/AbstractRecipeItem.java
+++ b/app/src/main/java/Entities/Implementations/AbstractRecipeItem.java
@@ -47,7 +47,7 @@ public abstract class AbstractRecipeItem extends AbstractEntity implements Recip
     }
 
     @Override
-    public float quantity() {
+    public double quantity() {
         return this.amount;
     }
 

--- a/app/src/main/java/Entities/Implementations/QuantityRecipeItem.java
+++ b/app/src/main/java/Entities/Implementations/QuantityRecipeItem.java
@@ -22,16 +22,15 @@ public class QuantityRecipeItem extends AbstractRecipeItem {
     }
 
     public String display() {
-        float tempQuantity = this.quantity();
         String stringQuantity;
 
         // checks if the quantity ends in .0 or .00 (whole number)
         if (this.quantity() % 1 == 0) {
             // make it an int to remove the decimal
-            stringQuantity = Integer.toString((int) tempQuantity);
+            stringQuantity = Integer.toString((int) this.quantity());
         } else {
             // Convert to a string for returning
-            stringQuantity = Float.toString(tempQuantity);
+            stringQuantity = Double.toString(this.quantity());
         }
 
         // if there is multiple of the item

--- a/app/src/main/java/Entities/Implementations/RecipeItemImpl.java
+++ b/app/src/main/java/Entities/Implementations/RecipeItemImpl.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public class RecipeItemImpl extends AbstractEntity implements RecipeItem  {
     private final Ingredient ingredient;
-    private final float amount;
+    private final double amount;
     private boolean optional = false;
     private RecipeItemDisplay displayObject = null;
 
@@ -16,7 +16,7 @@ public class RecipeItemImpl extends AbstractEntity implements RecipeItem  {
      * @param amount of this ingredient.
      * @param ingredient  The ingredient
      */
-    public RecipeItemImpl(Ingredient ingredient, float amount, boolean optional, RecipeItemDisplay displayObject) {
+    public RecipeItemImpl(Ingredient ingredient, double amount, boolean optional, RecipeItemDisplay displayObject) {
         super();
         this.ingredient = ingredient;
         this.amount = amount;
@@ -24,7 +24,7 @@ public class RecipeItemImpl extends AbstractEntity implements RecipeItem  {
         this.displayObject = displayObject;
     }
 
-    public RecipeItemImpl(UUID id, Ingredient ingredient, float amount, boolean optional, RecipeItemDisplay displayObject) {
+    public RecipeItemImpl(UUID id, Ingredient ingredient, double amount, boolean optional, RecipeItemDisplay displayObject) {
         super(id);
         this.ingredient = ingredient;
         this.amount = amount;
@@ -38,7 +38,7 @@ public class RecipeItemImpl extends AbstractEntity implements RecipeItem  {
     }
 
     @Override
-    public float quantity() {
+    public double quantity() {
         return this.amount;
     }
 

--- a/app/src/main/java/Entities/Implementations/ReferencedRecipeItem.java
+++ b/app/src/main/java/Entities/Implementations/ReferencedRecipeItem.java
@@ -24,7 +24,7 @@ public class ReferencedRecipeItem extends ReferencedEntity<RecipeItem> implement
 	}
 
 	@Override
-	public float quantity() {
+	public double quantity() {
 		try {
 			return this.entityReference.get().quantity();
 		} catch (NoSuchEntity noSuchEntity) {

--- a/app/src/main/java/Entities/Implementations/VolumetricRecipeItem.java
+++ b/app/src/main/java/Entities/Implementations/VolumetricRecipeItem.java
@@ -22,17 +22,16 @@ public class VolumetricRecipeItem extends AbstractRecipeItem {
         super(id, ingredient, amount, optional);
     }
 
-    public String display(){
-        float tempQuantity = this.quantity();
+    public String display() {
         String stringQuantity;
 
         // checks if the quantity ends in .0 or .00 (whole number)
         if (this.quantity() % 1 == 0) {
             // make it an int to remove the decimal
-            stringQuantity = Integer.toString((int) tempQuantity);
+            stringQuantity = Integer.toString((int) this.quantity());
         } else {
             // Convert to a string for returning
-            stringQuantity = Float.toString(tempQuantity);
+            stringQuantity = Double.toString(this.quantity());
         }
         return stringQuantity + "ml of " + this.ingredient().name();
     }

--- a/app/src/main/java/Entities/ItemDisplays/Mass.java
+++ b/app/src/main/java/Entities/ItemDisplays/Mass.java
@@ -8,7 +8,7 @@ public class Mass implements RecipeItemDisplay {
      * @return
      */
     @Override
-    public String display(float quantity, Ingredient ingredient) {
+    public String display(double quantity, Ingredient ingredient) {
         String stringQuantity;
 
         // checks if the quantity ends in .0 or .00 (whole number)
@@ -17,7 +17,7 @@ public class Mass implements RecipeItemDisplay {
             stringQuantity = Integer.toString((int) quantity);
         } else {
             // Convert to a string for returning
-            stringQuantity = Float.toString(quantity);
+            stringQuantity = Double.toString(quantity);
         }
         return stringQuantity + "g of " + ingredient.name();
     }

--- a/app/src/main/java/Entities/ItemDisplays/Quantifiable.java
+++ b/app/src/main/java/Entities/ItemDisplays/Quantifiable.java
@@ -5,7 +5,7 @@ import Entities.Ingredient;
 public class Quantifiable implements RecipeItemDisplay {
 
     @Override
-    public String display(float quantity, Ingredient ingredient) {
+    public String display(double quantity, Ingredient ingredient) {
         String stringQuantity;
 
         // checks if the quantity ends in .0 or .00 (whole number)
@@ -14,7 +14,7 @@ public class Quantifiable implements RecipeItemDisplay {
             stringQuantity = Integer.toString((int) quantity);
         } else {
             // Convert to a string for returning
-            stringQuantity = Float.toString(quantity);
+            stringQuantity = Double.toString(quantity);
         }
 
         // if there is multiple of the item

--- a/app/src/main/java/Entities/ItemDisplays/RecipeItemDisplay.java
+++ b/app/src/main/java/Entities/ItemDisplays/RecipeItemDisplay.java
@@ -5,11 +5,11 @@ import Entities.Ingredient;
 public interface RecipeItemDisplay {
     /**
      * Returns display information for each respective recipe item type and quantity
-     * @param quantity: float representing quantity
+     * @param quantity: Double representing quantity
      * @param ingredient: ingredient that the recipeItem is
      * @return String representing display
      */
-    String display(float quantity, Ingredient ingredient);
+    String display(double quantity, Ingredient ingredient);
 
     /**
      * Return serialized type for RecipeItem

--- a/app/src/main/java/Entities/ItemDisplays/Volumetric.java
+++ b/app/src/main/java/Entities/ItemDisplays/Volumetric.java
@@ -5,7 +5,7 @@ import Entities.Ingredient;
 public class Volumetric implements RecipeItemDisplay {
 
     @Override
-    public String display(float quantity, Ingredient ingredient) {
+    public String display(double quantity, Ingredient ingredient) {
         String stringQuantity;
 
         // checks if the quantity ends in .0 or .00 (whole number)
@@ -14,7 +14,7 @@ public class Volumetric implements RecipeItemDisplay {
             stringQuantity = Integer.toString((int) quantity);
         } else {
             // Convert to a string for returning
-            stringQuantity = Float.toString(quantity);
+            stringQuantity = Double.toString(quantity);
         }
         return stringQuantity + "ml of " + ingredient.name();
     }

--- a/app/src/main/java/Entities/RecipeItem.java
+++ b/app/src/main/java/Entities/RecipeItem.java
@@ -13,7 +13,7 @@ public interface RecipeItem extends Entity {
      *
      * @return int representing the quantity
      */
-    float quantity();
+    double quantity();
 
     /**
      * Whether this item is optional in its recipe

--- a/app/src/test/java/Entities/Builders/RecipeItemBuilderTest.java
+++ b/app/src/test/java/Entities/Builders/RecipeItemBuilderTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -40,13 +41,13 @@ public class RecipeItemBuilderTest {
 	public void testLoadEntity() throws InvalidRowShape {
 		UUID itemID = UUID.randomUUID();
 		UUID ingredientID = UUID.randomUUID();
-		Row row = new RowImpl("recipeItem", Map.of(
-						"id", itemID.toString(),
-						"ingredient", ingredientID.toString(),
-						"quantity", 0.5,
-						"optional", true,
-						"displayType", "q"
-		));
+		Map<String, Object> attributes = new HashMap<>();
+		attributes.put("id", itemID.toString());
+		attributes.put("ingredient", ingredientID.toString());
+		attributes.put("quantity", 0.5);
+		attributes.put("optional", true);
+		attributes.put("displayType", "q");
+		Row row = new RowImpl("recipeItem", attributes);
 
 		RecipeItem item = this.builder.loadEntity(row);
 		Assertions.assertEquals(itemID, item.id());
@@ -58,6 +59,11 @@ public class RecipeItemBuilderTest {
 						InvalidRowShape.class,
 						() -> this.builder.loadEntity(new EmptyRow())
 		);
+
+		// Allow any Number to be cast to doubles.
+		attributes.put("quantity", 3);
+		item = this.builder.loadEntity(row);
+		Assertions.assertEquals(3.0, item.quantity());
 	}
 
 	@Test

--- a/app/src/test/java/Entities/Serializers/RecipeItemSerializerTest.java
+++ b/app/src/test/java/Entities/Serializers/RecipeItemSerializerTest.java
@@ -29,7 +29,7 @@ public class RecipeItemSerializerTest {
 		Assertions.assertEquals(ingredient.id().toString(), row.get("ingredient", String.class));
 
 		// Ensure all properties of our items were assigned properly.
-		Assertions.assertEquals(1.4f, row.get("quantity", Float.class));
+		Assertions.assertEquals(1.4f, row.get("quantity", Double.class));
 		Assertions.assertFalse(row.get("optional", Boolean.class));
 		Assertions.assertEquals(item.serializeTypeCode(), row.get("displayType", String.class));
 	}

--- a/app/src/test/java/Loaders/Implementations/JSONFileIOTest.java
+++ b/app/src/test/java/Loaders/Implementations/JSONFileIOTest.java
@@ -3,14 +3,13 @@ package Loaders.Implementations;
 import Loaders.Exceptions.NoSuchAttribute;
 import Loaders.Row;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class JSONFileIOTest {
 
@@ -101,6 +100,19 @@ public class JSONFileIOTest {
 		String sourceNoSpace = SOURCE.replaceAll("\\s+", "");
 
 		Assertions.assertEquals(sourceNoSpace, jsonNoSpace);
+
+		// Ensure non-integer values are saved.
+		Map<String, Object> values = new HashMap<>();
+		values.put("val", 4.0);
+		Row row = new RowImpl("test", values);
+
+		writer = new StringWriter();
+		this.loader.save(Collections.singletonList(row), writer);
+		String rawJSON = writer.toString();
+
+		JSONObject obj = new JSONObject();
+		obj.put("test", 1.23);
+		Assertions.assertEquals("{\"test\":1.23}", obj.toString());
 	}
 
 }

--- a/app/src/test/java/Loaders/Implementations/RowImplTest.java
+++ b/app/src/test/java/Loaders/Implementations/RowImplTest.java
@@ -24,6 +24,7 @@ public class RowImplTest {
 		Map<String, Object> attributes = new HashMap<>();
 		attributes.put("a", 1);
 		attributes.put("b", 2);
+		attributes.put("c", 3.0);
 		attributes.put("l", list);
 		attributes.put("m", map);
 


### PR DESCRIPTION
The JSON stores doubles that have no fractional part as an integer when string-ified. So this simple change allows for the recipe item builder to ignore this issue in casting.